### PR TITLE
Add one example for error locating

### DIFF
--- a/examples/NoInstance.hs
+++ b/examples/NoInstance.hs
@@ -1,0 +1,4 @@
+module NoInstance where
+
+foo :: a -> a -> a
+foo a b = a + b

--- a/examples/no-instnace.json
+++ b/examples/no-instnace.json
@@ -1,0 +1,23 @@
+{
+    "fileName": "NoInstance.hs",
+    "moduleName": "NoInstance",
+    "errors": [
+        {
+            "message": "The use of \"=\" in \"foo\" requires its operands to have an \"Eq\" instance",
+            "locations": [
+                {
+                    "fromLine": 4,
+                    "toLine": 4,
+                    "fromColumn": 1,
+                    "toColumn": 4
+                },   
+                {
+                    "fromLine": 4,
+                    "toLine": 4,
+                    "fromColumn": 11,
+                    "toColumn": 16
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
In this pull request I include two files under `projectroot/examples` directory.
- `NoInstance.hs` -- for testing purpose
- `no-instance.json` -- include some information about the problem in the former item. 

The goal here is to implement a `haskellDebugging.showHighlight` command in this extension. 
Give it proper metadata: e.g. name, category and description.
Set the configuration (i.e. `package.json`) keys properly, so the command can be invoked from command pallet .
And make it do something, look below.

# Expected result
Open the evelyn-extension project in vs-code
Compile your code, may be by running `npm run compile` or `nom run watch` in command line
Navigate to Run panel by click on the "🐛▶" button on the left side navigation bar
Select "Run extension" and click the "Start debugging" button
Wait for the debugging instance of vs-code to run
In the debugging instance of vs-code, click on the file -> open folder in menu bar
Select `evelyn-extension/examples`  folder and click OK
Open up the `NoInstance.hs` file
Fire up your "show-highlight" command
Some visual effect will highlight the region of error: foo definition and "a + b" part. The specification can be found in `evelyn-extension/examples/no-instance.json` file

# Some pointers
Read the json file into your typescript using "import myVariable from `./examples/no-instance.json`
Parse the json file properly using `JSON.parse` function. 
Figure out how to interact with current editor buffer.
No requirements given on what visual effect should use. 

