### PR TITLE
More elaberate example

### DIFF
--- a/examples/Incompatibility.hs
+++ b/examples/Incompatibility.hs
@@ -1,0 +1,6 @@
+module Incompatibility where
+
+whoIsRight x = 
+    if x
+    then "X is True"
+    else 41

--- a/examples/No-Instance.hs
+++ b/examples/No-Instance.hs
@@ -1,4 +1,4 @@
 module NoInstance where
 
-foo :: a -> a -> a
-foo a b = a + b
+foo :: a -> a -> Bool
+foo a b = a == a

--- a/examples/no-instance.json
+++ b/examples/no-instance.json
@@ -3,18 +3,18 @@
     "moduleName": "NoInstance",
     "errors": [
         {
-            "message": "The use of \"=\" in \"foo\" requires its operands to have an \"Eq\" instance",
+            "message": "The use of \"==\" in \"foo\" requires its operands to have an \"Eq\" instance",
             "locations": [
                 {
-                    "fromLine": 4,
-                    "toLine": 4,
-                    "fromColumn": 1,
-                    "toColumn": 4
+                    "fromLine": 3,
+                    "toLine": 3,
+                    "fromColumn": 0,
+                    "toColumn": 3
                 },   
                 {
-                    "fromLine": 4,
-                    "toLine": 4,
-                    "fromColumn": 11,
+                    "fromLine": 3,
+                    "toLine": 3,
+                    "fromColumn": 10,
                     "toColumn": 16
                 }
             ]

--- a/examples/no-instance.txt
+++ b/examples/no-instance.txt
@@ -3,18 +3,18 @@
     "moduleName": "NoInstance",
     "errors": [
         {
-            "message": "The use of \"=\" in \"foo\" requires its operands to have an \"Eq\" instance",
+            "message": "The use of \"==\" in \"foo\" requires its operands to have an \"Eq\" instance",
             "locations": [
                 {
-                    "fromLine": 4,
-                    "toLine": 4,
-                    "fromColumn": 1,
-                    "toColumn": 4
+                    "fromLine": 3,
+                    "toLine": 3,
+                    "fromColumn": 0,
+                    "toColumn": 3
                 },   
                 {
-                    "fromLine": 4,
-                    "toLine": 4,
-                    "fromColumn": 11,
+                    "fromLine": 3,
+                    "toLine": 3,
+                    "fromColumn": 10,
                     "toColumn": 16
                 }
             ]

--- a/src/Incompatibility-chooseNumber.json
+++ b/src/Incompatibility-chooseNumber.json
@@ -1,0 +1,23 @@
+{
+    "fileName": "Incompatibility.hs",
+    "moduleName": "Incompatibility",
+    "errors": [
+        {
+            "message": "The type of \"whoIsRight\" has wrong type in the highlighted location'",
+            "locations": [
+                {
+                    "fromLine": 2,
+                    "toLine": 2,
+                    "fromColumn": 0,
+                    "toColumn": 10
+                },   
+                {
+                    "fromLine": 4,
+                    "toLine": 4,
+                    "fromColumn": 9,
+                    "toColumn": 20
+                }
+            ]
+        }
+    ]
+}

--- a/src/Incompatibility-chooseString.json
+++ b/src/Incompatibility-chooseString.json
@@ -1,0 +1,23 @@
+{
+    "fileName": "Incompatibility.hs",
+    "moduleName": "Incompatibility",
+    "errors": [
+        {
+            "message": "The type of \"whoIsRight\" has wrong type in the highlighted location'",
+            "locations": [
+                {
+                    "fromLine": 2,
+                    "toLine": 2,
+                    "fromColumn": 0,
+                    "toColumn": 10
+                },   
+                {
+                    "fromLine": 5,
+                    "toLine": 5,
+                    "fromColumn": 9,
+                    "toColumn": 11
+                }
+            ]
+        }
+    ]
+}

--- a/src/incompatiblility.json
+++ b/src/incompatiblility.json
@@ -1,0 +1,29 @@
+{
+    "fileName": "Incompatibility.hs",
+    "moduleName": "Incompatibility",
+    "errors": [
+        {
+            "message": "The type of \"whoIsRight\" can be either 'Bool -> String' or 'Num a => Bool -> a'",
+            "locations": [
+                {
+                    "fromLine": 2,
+                    "toLine": 2,
+                    "fromColumn": 0,
+                    "toColumn": 10
+                },   
+                {
+                    "fromLine": 4,
+                    "toLine": 4,
+                    "fromColumn": 9,
+                    "toColumn": 20
+                },
+                {
+                    "fromLine": 5,
+                    "toLine": 5,
+                    "fromColumn": 9,
+                    "toColumn": 11
+                }
+            ]
+        }
+    ]
+}

--- a/src/no-instance.json
+++ b/src/no-instance.json
@@ -3,7 +3,7 @@
     "moduleName": "NoInstance",
     "errors": [
         {
-            "message": "The use of \"=\" in \"foo\" requires its operands to have an \"Eq\" instance",
+            "message": "The use of \"==\" in \"foo\" requires its operands to have an \"Eq\" instance",
             "locations": [
                 {
                     "fromLine": 3,
@@ -15,7 +15,7 @@
                     "fromLine": 3,
                     "toLine": 3,
                     "fromColumn": 10,
-                    "toColumn": 15
+                    "toColumn": 16
                 }
             ]
         }


### PR DESCRIPTION
This time we want to add a few more vs-code extension capabilities into play. 
The example files include `./examples/Incompatibility.hs` and three json files under `./src`. 
We want to present the error using the `./src/Incompatibility.json` and also prompt users two options. 
- To give the expression `Bool -> String` type.  At this point we use the  `./src/Incompatibility-chooseString.json`  to generate new diagnostics
- To give the expression `Bool -> Number` type.  At this point we use the  `./src/Incompatibility-chooseNumber.json`  to generate new diagnostics

We may need the https://github.com/microsoft/vscode-extension-samples/tree/master/code-actions-sample for presenting choices. But if you find other features from the API that are more effective, it is absolutely fine too.